### PR TITLE
A new formula to install and compile the package IMG

### DIFF
--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -28,6 +28,7 @@ class Gap < Formula
     #   This use of `libexec` seems to contradict Linux Filesystem Hierarchy
     #   Standard, but is recommended in Homebrew's "Formula Cookbook."
 
+    pkgshare.install Dir["pkg"]
     libexec.install Dir["*"]
 
     # GAP does not support "make install" so it has to be compiled in place
@@ -39,14 +40,19 @@ class Gap < Formula
 
     # Create a symlink `bin/gap` from the `gap` binary
     bin.install_symlink libexec/"gap" => "gap"
+    libexec.install_symlink pkgshare/"pkg" => "pkg"
 
     ohai "Building included packages. Please be patient, it may take a while"
-    cd libexec/"pkg" do
+    cd pkgshare/"pkg" do
       # NOTE: This script will build most of the packages that require
       # compilation. It is known to produce a number of warnings and
       # error messages, possibly failing to build several packages.
-      system "../bin/BuildPackages.sh", "--with-gaproot=#{libexec}"
+      system "../../../libexec/bin/BuildPackages.sh", "--with-gaproot=#{libexec}"
     end
+
+    # Now remove the symlink to pkgshare/"pkg", and put one to HOMEBREW_PREFIX/share/gap/pkg, so we can access global packages too
+    rm libexec/"pkg"
+    ln_s "#{HOMEBREW_PREFIX}/share/gap/pkg", libexec/"pkg"
   end
 
   test do

--- a/Formula/img.rb
+++ b/Formula/img.rb
@@ -1,0 +1,29 @@
+class Img < Formula
+  desc "Iterated monodromy groups in GAP"
+  homepage "https://gap-packages.github.io/img/"
+  url "https://github.com/gap-packages/img/releases/download/v0.3.0/IMG-0.3.0.tar.gz"
+  sha256 "41a59cf49be79b2f617e0e5d1f1e73838e6bd2f1d2ea3f234177a31c33c6826d"
+  license "GPL-3"
+
+  depends_on "gap-system/gap/gap"
+  depends_on "cmake" => :build
+  depends_on "openblas" => :build
+  depends_on "suite-sparse" => :build
+  
+  bottle :unneeded
+  
+  def install
+    system "./configure", "--with-gaproot=#{Formula["gap-system/gap/gap"].opt_prefix}/libexec"
+    system "make"
+    (share/"gap/pkg/img-0.3.0").install Dir["*"]
+  end
+
+  test do
+    (testpath/"test1.g").write <<~EOF
+OnBreak:=function() Print("FATAL ERROR"); FORCE_QUIT_GAP(1); end;;
+LoadPackage("img");
+FORCE_QUIT_GAP(0);
+EOF
+    system Formula["gap-system/gap/gap"].opt_prefix/"bin/gap", "test1.g"
+  end
+end


### PR DESCRIPTION
This is an example of a formula, that actually works well on my homebrew, and installs (compiles and places in appropriate place) my package IMG for use with the homebrew-gap version of gap.