### PR TITLE
Use make install

### DIFF
--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -28,15 +28,11 @@ class Gap < Formula
   depends_on "mpfr"     # float, normalizinterface
   depends_on "ncurses"  # browse
   depends_on "zeromq"   # ZeroMQInterface
-
+  depends_on "singular" # many packages
+  depends_on "pari"     # many packages
 
   def install
 
-    prerequisites_packages = [
-      "atlasrep",
-      "normalizinterface",
-      "semigroups",
-    ]
 
     no_compilation_packages = [
       "atlasrep", "aclib", "agt", "alnuth", "automata", "automgrp",
@@ -58,10 +54,8 @@ class Gap < Formula
       "thelma", "tomlib", "toric", "transgrp", "ugaly", "unipot",
       "unitlib", "utils", "uuid", "walrus", "wedderga", "xmod",
       "xmodalg", "yangbaxter",
-    ]
-
-    # make doc and test targets, I don't actually call them
-    makefile_packages = [
+      # These packages have `doc` and `test` make targets, but we
+      # don't actually call them
       "4ti2interface", "autodoc", "cap", "examplesforhomalg",
       "gaussforhomalg", "generalizedmorphismsforcap", "gradedmodules",
       "gradedringforhomalg", "homalg", "homalgtocas", "io_forhomalg",
@@ -85,20 +79,11 @@ class Gap < Formula
       "guava", "kbmag",
     ]
 
-    # These package have autogen.sh available
-    # I don't think there is a need to run it, but we could if we wanted
-    autogen_packages = [
-      "anupq", "cddinterface", "curlinterface", "digraphs", "ferret",
-      "float", "guava", "io", "normalizinterface", "nq", "semigroups",
-      "simpcomp", "xgap", "zeromqinterface",
-    ]
 
-    # Run special commands after installation
-    special_packages = {
-      # Even with x11 installed, it doesn't seem to work
-      # "xgap" => "cp bin/xgap.sh $GAPROOT/bin/xgap.sh",
-    }
 
+    all_packages = no_compilation_packages
+                     .concat(configure_packages)
+                     .concat(configure_packages)
 
     # Start actually building GAP
     if build.head?
@@ -126,21 +111,15 @@ class Gap < Formula
 
       # The makefiles appear to only be used for docs...
       # The BuildPackages.sh script didn't call them
-      no_compilation_packages.concat(makefile_packages).each do |pkg|
+      all_packages.each do |pkg|
         system "cp", "-R", pkg, "#{libexec}/gap/lib/gap/pkg/"
-      end
-
-      prerequisites_packages.each do |pkg|
         cd pkg do
-          system "./prerequisites.sh", "#{libexec}/gap/lib/gap"
+          if File.exist?("./prerequisites.sh")
+            system "./prerequisites.sh", "#{libexec}/gap/lib/gap"
+          end
         end
       end
 
-      # autogen_packages.each do |pkg|
-      #   cd pkg do
-      #     system "./autogen.sh"
-      #   end
-      # end
       configure_packages.each do |pkg|
         cd pkg do
           system "./configure", "--with-gaproot=#{libexec}/gap/lib/gap"

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -19,8 +19,15 @@ class Gap < Formula
   # So we depend on GNU readline here.
   depends_on "readline"
 
-  # for zeromqinterface package
-  depends_on "zeromq"
+  # for packages
+  depends_on "cddlib"   # CddInterface
+  depends_on "curl"     # curlInterface
+  depends_on "fplll"    # float
+  depends_on "libmpc"   # float
+  depends_on "mpfi"     # float
+  depends_on "mpfr"     # float, normalizinterface
+  depends_on "ncurses"  # browse
+  depends_on "zeromq"   # ZeroMQInterface
 
 
   def install

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -3,10 +3,14 @@ class Gap < Formula
   homepage "https://www.gap-system.org/"
   url "https://github.com/gap-system/gap/releases/download/v4.12.2/gap-4.12.2.tar.gz"
   sha256 "672308745eb78a222494ee8dd6786edd5bc331456fcc6456ac064bdb28d587a8"
+  license "GPL-2.0-or-later"
+
+
   head do
     url "https://github.com/gap-system/gap.git", branch: "master"
-    depends_on "autoconf" => :build
+    depends_on "autoconf" => :build # required by packages below
   end
+
 
   depends_on "gmp"
   # GAP cannot be built against the native macOS version of readline
@@ -15,47 +19,135 @@ class Gap < Formula
   # So we depend on GNU readline here.
   depends_on "readline"
 
+  # for zeromqinterface package
+  depends_on "zeromq"
+
+
   def install
-    # XXX:  Currently there is no `install` target in `Makefile`.
-    #   According to the manual installation instructions in
-    #
-    #     https://github.com/gap-system/gap/blob/master/INSTALL.md
-    #
-    #   the compiled "bundle" is intended to be used "as is," and there is
-    #   no instructions for how to remove the source and other unnecessary
-    #   files after compilation.  Moreover, the content of the
-    #   subdirectories with special names, such as `bin` and `lib`, is not
-    #   suitable for merging with the content of the corresponding
-    #   subdirectories of `/usr/local`.  The easiest temporary solution seems
-    #   to be to drop the compiled bundle into `<prefix>/libexec` and to
-    #   create a symlink `<prefix>/bin/gap` to the startup script.
-    #   This use of `libexec` seems to contradict Linux Filesystem Hierarchy
-    #   Standard, but is recommended in Homebrew's "Formula Cookbook."
 
-    libexec.install Dir["*"]
+    prerequisites_packages = [
+      "atlasrep",
+      "normalizinterface",
+      "semigroups",
+    ]
 
-    # GAP does not support "make install" so it has to be compiled in place
+    no_compilation_packages = [
+      "atlasrep", "aclib", "agt", "alnuth", "automata", "automgrp",
+      "autpgrp", "circle", "classicpres", "congruence", "corelg",
+      "crime", "crisp", "cryst", "crystcat", "ctbllib", "cubefree",
+      "design", "difsets", "factint", "fga", "fining", "format",
+      "forms", "fr", "francy", "fwtree", "gapdoc", "gbnp", "genss",
+      "groupoids", "grpconst", "guarana", "hap", "hapcryst", "hecke",
+      "help", "idrel", "images", "intpic", "irredsol", "itc",
+      "jupyterkernel", "jupyterviz", "kan", "laguna", "liealgdb",
+      "liepring", "liering", "loops", "lpres", "majoranaalgebras",
+      "mapclass", "matgrp", "modisom", "nilmat", "nock",
+      "numericalsgps", "openmath", "packagemanager", "patternclass",
+      "permut", "polenta", "polycyclic", "polymaking", "primgrp",
+      "qpa", "quagroup", "radiroot", "rcwa", "rds", "recog",
+      "repndecomp", "repsn", "resclasses", "scscp", "sglppow",
+      "sgpviz", "singular", "sl2reps", "sla", "smallgrp", "smallsemi",
+      "sonata", "sophus", "spinsym", "standardff", "symbcompcc",
+      "thelma", "tomlib", "toric", "transgrp", "ugaly", "unipot",
+      "unitlib", "utils", "uuid", "walrus", "wedderga", "xmod",
+      "xmodalg", "yangbaxter",
+    ]
 
-    cd libexec do
-      if build.head?
-        system "./autogen.sh"
-      end
-      system "./configure", "--with-readline=#{Formula["readline"].opt_prefix}"
-      system "make"
-      if build.head? # option for minimal packages? bootstrap-pkg-minimal
-        system "make", "bootstrap-pkg-full"
-      end
+    # make doc and test targets, I don't actually call them
+    makefile_packages = [
+      "4ti2interface", "autodoc", "cap", "examplesforhomalg",
+      "gaussforhomalg", "generalizedmorphismsforcap", "gradedmodules",
+      "gradedringforhomalg", "homalg", "homalgtocas", "io_forhomalg",
+      "linearalgebraforcap", "localizeringforhomalg",
+      "matricesforhomalg", "modulepresentationsforcap", "modules",
+      "monoidalcategories", "nconvex", "ringsforhomalg", "sco",
+      "toolsforhomalg", "toricvarieties",
+    ]
+
+    # These two packages either don't build or don't work
+    # "cddinterface", "xgap",
+    configure_packages = [
+      "anupq", "caratinterface", "crypting", "curlinterface", "cvec",
+      "datastructures", "deepthought", "digraphs", "ferret", "float",
+      "gauss", "grape", "io", "json", "normalizinterface", "nq",
+      "orb", "profiling", "semigroups", "simpcomp", "zeromqinterface",
+      ]
+
+    old_configure_packages = [
+      "ace", "browse", "cohomolo", "edim", "example", "fplsa",
+      "guava", "kbmag",
+    ]
+
+    # These package have autogen.sh available
+    # I don't think there is a need to run it, but we could if we wanted
+    autogen_packages = [
+      "anupq", "cddinterface", "curlinterface", "digraphs", "ferret",
+      "float", "guava", "io", "normalizinterface", "nq", "semigroups",
+      "simpcomp", "xgap", "zeromqinterface",
+    ]
+
+    # Run special commands after installation
+    special_packages = {
+      # Even with x11 installed, it doesn't seem to work
+      # "xgap" => "cp bin/xgap.sh $GAPROOT/bin/xgap.sh",
+    }
+
+
+    # Start actually building GAP
+    if build.head?
+      system "./autogen.sh"
     end
 
+    libexec.install Dir["pkg"]
+
+    system "./configure", "--prefix", libexec/"gap", "--with-readline=#{Formula["readline"].opt_prefix}"
+    if build.head?
+      system "make", "bootstrap-pkg-full"
+      # system "make", "doc"      # Do we need this?
+    end
+    system "make", "install"
+
     # Create a symlink `bin/gap` from the `gap` binary
-    bin.install_symlink libexec/"gap" => "gap"
+    bin.install_symlink libexec/"gap/bin/gap" => "gap"
 
     ohai "Building included packages. Please be patient, it may take a while"
+    pkg_dir = "#{libexec}/pkg"
+
     cd libexec/"pkg" do
-      # NOTE: This script will build most of the packages that require
-      # compilation. It is known to produce a number of warnings and
-      # error messages, possibly failing to build several packages.
-      system "../bin/BuildPackages.sh", "--with-gaproot=#{libexec}"
+
+      system "mkdir", "#{libexec}/gap/lib/gap/pkg/"
+
+      # The makefiles appear to only be used for docs...
+      # The BuildPackages.sh script didn't call them
+      no_compilation_packages.concat(makefile_packages).each do |pkg|
+        system "cp", "-R", pkg, "#{libexec}/gap/lib/gap/pkg/"
+      end
+
+      prerequisites_packages.each do |pkg|
+        cd pkg do
+          system "./prerequisites.sh", "#{libexec}/gap/lib/gap"
+        end
+      end
+
+      # autogen_packages.each do |pkg|
+      #   cd pkg do
+      #     system "./autogen.sh"
+      #   end
+      # end
+      configure_packages.each do |pkg|
+        cd pkg do
+          system "./configure", "--with-gaproot=#{libexec}/gap/lib/gap"
+          system "make"
+          system "/usr/bin/rsync", "-aEvL", "bin/", "#{libexec}/gap/lib/gap/pkg/"
+        end
+      end
+      old_configure_packages.each do |pkg|
+        cd pkg do
+          system "./configure", "#{libexec}/gap/lib/gap"
+          system "make"
+          system "/usr/bin/rsync", "-aEvL", "bin/", "#{libexec}/gap/lib/gap/pkg/"
+        end
+      end
     end
   end
 
@@ -63,4 +155,5 @@ class Gap < Formula
     ENV["LC_CTYPE"] = "en_GB.UTF-8"
     system bin/"gap", "-r", "-A", "#{libexec}/tst/testinstall.g"
   end
+
 end

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -3,6 +3,10 @@ class Gap < Formula
   homepage "https://www.gap-system.org/"
   url "https://github.com/gap-system/gap/releases/download/v4.12.2/gap-4.12.2.tar.gz"
   sha256 "672308745eb78a222494ee8dd6786edd5bc331456fcc6456ac064bdb28d587a8"
+  head do
+    url "https://github.com/gap-system/gap.git", branch: "master"
+    depends_on "autoconf" => :build
+  end
 
   depends_on "gmp"
   # GAP cannot be built against the native macOS version of readline
@@ -33,8 +37,14 @@ class Gap < Formula
     # GAP does not support "make install" so it has to be compiled in place
 
     cd libexec do
+      if build.head?
+        system "./autogen.sh"
+      end
       system "./configure", "--with-readline=#{Formula["readline"].opt_prefix}"
       system "make"
+      if build.head? # option for minimal packages? bootstrap-pkg-minimal
+        system "make", "bootstrap-pkg-full"
+      end
     end
 
     # Create a symlink `bin/gap` from the `gap` binary

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -124,14 +124,14 @@ class Gap < Formula
         cd pkg do
           system "./configure", "--with-gaproot=#{libexec}/gap/lib/gap"
           system "make"
-          system "/usr/bin/rsync", "-aEvL", "bin/", "#{libexec}/gap/lib/gap/pkg/"
+          system "cp", "-R", "bin/", "#{libexec}/gap/lib/gap/pkg/#{pkg}"
         end
       end
       old_configure_packages.each do |pkg|
         cd pkg do
           system "./configure", "#{libexec}/gap/lib/gap"
           system "make"
-          system "/usr/bin/rsync", "-aEvL", "bin/", "#{libexec}/gap/lib/gap/pkg/"
+          system "cp", "-R", "bin/", "#{libexec}/gap/lib/gap/pkg/#{pkg}"
         end
       end
     end


### PR DESCRIPTION
This switches from building in place to using `make install` to install to the Cellar.  This should fix #14.  Please let me know if I installed the packages to the wrong location or something.

I took the approach of listing every package explicitly, and whether it used the new or old style configure.  It seemed like that was consensus on how it should work, but I'm happy to change it to work more like `BuildPackages.sh`.

It's built on top of #16 because I didn't want to have to rebase everything.  If that's not desired, then I can get rid of the `--HEAD` option, I don't have too strong of feelings.

I'm a little worried that I didn't explicitly require all the dependencies I should have, but I just didn't notice because I already had them installed on my machine.

Two packages just don't work yet, namely `xgap` and `cddinterface`.

I have lightly tested the installation and it seems sane, though some of the singular packages fail their tests due to some minor differences (perhaps my singular is older or new than the one used when writing the tests).


Closes #16
Resolves #15
Resolves #14
Resolves #1