### PR TITLE
Use gap 4.13.0

### DIFF
--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -1,8 +1,8 @@
 class Gap < Formula
   desc "System for computational discrete algebra"
   homepage "https://www.gap-system.org/"
-  url "https://github.com/gap-system/gap/releases/download/v4.12.2/gap-4.12.2.tar.gz"
-  sha256 "672308745eb78a222494ee8dd6786edd5bc331456fcc6456ac064bdb28d587a8"
+  url "https://github.com/gap-system/gap/releases/download/v4.13.0/gap-4.13.0.tar.gz"
+  sha256 "cc76ecbe33d6719450a593e613fb87e9e4247faa876f632dd0f97c398f92265d"
 
   depends_on "gmp"
   # GAP cannot be built against the native macOS version of readline


### PR DESCRIPTION
Tested on macOS M1 home-brew