### PR TITLE
Update to 4.14.0 GAP

### DIFF
--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -1,8 +1,8 @@
 class Gap < Formula
   desc "System for computational discrete algebra"
   homepage "https://www.gap-system.org/"
-  url "https://github.com/gap-system/gap/releases/download/v4.13.0/gap-4.13.0.tar.gz"
-  sha256 "cc76ecbe33d6719450a593e613fb87e9e4247faa876f632dd0f97c398f92265d"
+  url "https://github.com/gap-system/gap/releases/download/v4.14.0/gap-4.14.0.tar.gz"
+  sha256 "845f5272c26feb1b8eb9ef294bf0545f264c1fe5a19b0601bbc65d79d9506487"
 
   depends_on "gmp"
   # GAP cannot be built against the native macOS version of readline


### PR DESCRIPTION
Update link and sha256 sum. This should work.

On Macbook '25 takes 3:26 to successfully install.

```zsh
➜  /tmp wget https://raw.githubusercontent.com/glinskikhg/homebrew-gap/refs/heads/master/Formula/gap.rb
--2025-07-10 23:39:57--  https://raw.githubusercontent.com/glinskikhg/homebrew-gap/refs/heads/master/Formula/gap.rb
Распознаётся raw.githubusercontent.com (raw.githubusercontent.com)… 185.199.108.133, 185.199.111.133, 185.199.109.133, ...
Подключение к raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... соединение установлено.
HTTP-запрос отправлен. Ожидание ответа… 200 OK
Длина: 2337 (2,3K) [text/plain]
Сохранение в: «gap.rb»

gap.rb                           100%[==========================================================>]   2,28K  --.-KB/s    за 0s      

2025-07-10 23:39:58 (12,6 MB/s) - «gap.rb» сохранён [2337/2337]

➜  /tmp brew install --formula gap.rb
==> Fetching gap
==> Downloading https://github.com/gap-system/gap/releases/download/v4.14.0/gap-4.14.0.tar.gz
==> Downloading from https://release-assets.githubusercontent.com/github-production-release-asset/31270208/0709c8ef-5d7f-40a3-902e-1
############################################################################################################################# 100.0%
==> ./configure --with-readline=/opt/homebrew/opt/readline
==> make
==> Building included packages. Please be patient, it may take a while
==> ../bin/BuildPackages.sh --with-gaproot=/opt/homebrew/Cellar/gap/4.14.0/libexec
🍺  /opt/homebrew/Cellar/gap/4.14.0: 55,859 files, 1.2GB, built in 3 minutes 26 seconds
==> Running `brew cleanup gap`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

➜  /tmp /opt/homebrew/Cellar/gap/4.14.0/bin/gap --version
GAP 4.14.0 built on reproducible%  
```