### PR TITLE
add standard Homebrew actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: brew pr-pull
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  pr-pull:
+    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: write
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up git
+        uses: Homebrew/actions/git-user-config@main
+
+      - name: Pull bottles
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@main
+        with:
+          branch: main
+
+      - name: Delete branch
+        if: github.event.pull_request.head.repo.fork == false
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,51 @@
+name: brew test-bot
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test-bot:
+    strategy:
+      matrix:
+        os: [ macos-15-intel, macos-26 ]
+        include:
+          - os: ubuntu-latest
+            container: ghcr.io/homebrew/brew:main
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache Homebrew Bundler RubyGems
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.os }}-rubygems-
+
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      - run: brew test-bot --only-tap-syntax
+      - run: brew test-bot --only-formulae
+        if: github.event_name == 'pull_request'
+
+      - name: Upload bottles as artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bottles_${{ matrix.os }}
+          path: '*.bottle.*'

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -8,6 +8,7 @@ class Gap < Formula
   # most dependencies are for for packages; only gmp and readline are for GAP itself
   depends_on "cddlib"   # CddInterface
   depends_on "curl"     # curlInterface
+  depends_on "flint"    # a 2nd order dep.
   depends_on "fplll"    # float
   depends_on "gmp"      # - for main GAP
   depends_on "libmpc"   # float
@@ -22,6 +23,7 @@ class Gap < Formula
   depends_on "readline" # - for main GAP
   depends_on "singular" # many packages
   depends_on "zeromq"   # ZeroMQInterface
+  depends_on "zlib-ng-compat" # a 2nd order dep.
 
   def install
     system "./configure", *std_configure_args
@@ -38,6 +40,11 @@ class Gap < Formula
       # compilation. It is known to produce a number of warnings and
       # error messages, possibly failing to build several packages.
       system buildpath/"bin/BuildPackages.sh", "--with-gaproot=#{lib}/gap"
+      rm Dir.glob("#{lib}/gap/pkg/**/*.log")
+      rm Dir.glob("#{lib}/gap/pkg/**/config.status")
+      rm Dir.glob("#{lib}/gap/pkg/**/*.out")
+      rm Dir.glob("#{lib}/gap/pkg/**/Makefile")
+      rm Dir.glob("#{lib}/gap/pkg/**/libtool")
     end
   end
 

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -21,7 +21,7 @@ class Gap < Formula
   # it requires either GNU readline, or no readline at all; but
   # the latter leads to an inferior user experience.
   # So we depend on GNU readline here.
-  depends_on "readline" # - for main GAP
+  depends_on "readline" # for GAP itself
   depends_on "singular" # many packages
   depends_on "zeromq"   # ZeroMQInterface
   depends_on "zlib-ng-compat" # a 2nd order dep.

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -5,25 +5,23 @@ class Gap < Formula
   sha256 "6049d53e99b12e25c2d848db21ac4a06380a46fe4c4157243d556fe06930042c"
   license "GPL-2.0-or-later"
 
-  depends_on "gmp"
-  # GAP cannot be built against the native macOS version of readline
-  # it requires either GNU readline, or no readline at all; but
-  # the latter leads to an inferior user experience.
-  # So we depend on GNU readline here.
-  depends_on "readline"
-
-  # for packages
+  # most dependencies are for for packages; only gmp and readline are for GAP itself
   depends_on "cddlib"   # CddInterface
   depends_on "curl"     # curlInterface
   depends_on "fplll"    # float
+  depends_on "gmp"      # - for main GAP
   depends_on "libmpc"   # float
   depends_on "mpfi"     # float
   depends_on "mpfr"     # float, normalizinterface
   depends_on "ncurses"  # browse
   depends_on "pari"     # alnuth
+  # GAP cannot be built against the native macOS version of readline
+  # it requires either GNU readline, or no readline at all; but
+  # the latter leads to an inferior user experience.
+  # So we depend on GNU readline here.
+  depends_on "readline" # - for main GAP
   depends_on "singular" # many packages
   depends_on "zeromq"   # ZeroMQInterface
-
 
   def install
     system "./configure", *std_configure_args
@@ -31,8 +29,9 @@ class Gap < Formula
 
     ohai "Building included packages. Please be patient, it may take a while"
 
-    system "mkdir", "-p", "#{lib}/gap/"
-    system "cp", "-R", "pkg", "#{lib}/gap/pkg"
+    require "fileutils"
+    mkdir_p "#{lib}/gap/"
+    cp_r "pkg", "#{lib}/gap/pkg"
 
     cd lib/"gap/pkg" do
       # NOTE: This script will build most of the packages that require

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -1,6 +1,7 @@
 class Gap < Formula
   desc "System for computational discrete algebra"
-  homepage "https://www.gap-system.org/"
+  # homepage "https://www.gap-system.org/" - too slow for test-bot
+  homepage "https://github.com/gap-system/gap"
   url "https://github.com/gap-system/gap/releases/download/v4.15.1/gap-4.15.1.tar.gz"
   sha256 "6049d53e99b12e25c2d848db21ac4a06380a46fe4c4157243d556fe06930042c"
   license "GPL-2.0-or-later"
@@ -43,6 +44,7 @@ class Gap < Formula
       rm Dir.glob("#{lib}/gap/pkg/**/*.log")
       rm Dir.glob("#{lib}/gap/pkg/**/config.status")
       rm Dir.glob("#{lib}/gap/pkg/**/*.out")
+      rm Dir.glob("#{lib}/gap/pkg/**/*.err") # semigroups fails to build on macOS 26
       rm Dir.glob("#{lib}/gap/pkg/**/Makefile")
       rm Dir.glob("#{lib}/gap/pkg/**/libtool")
     end

--- a/Formula/gap.rb
+++ b/Formula/gap.rb
@@ -11,7 +11,7 @@ class Gap < Formula
   depends_on "curl"     # curlInterface
   depends_on "flint"    # a 2nd order dep.
   depends_on "fplll"    # float
-  depends_on "gmp"      # - for main GAP
+  depends_on "gmp"      # for GAP itself, but also anupq, nq, ...
   depends_on "libmpc"   # float
   depends_on "mpfi"     # float
   depends_on "mpfr"     # float, normalizinterface


### PR DESCRIPTION
Nowadays

   brew tap-new $YOUR_GITHUB_USERNAME/homebrew-tap

will create the .yml files with the actions; so I just copied them from my recent tap where they are working: dimpase/tap

cf. https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap

This will fix #19 